### PR TITLE
Remove `id` special case for field arrays

### DIFF
--- a/.changeset/silver-rules-brake.md
+++ b/.changeset/silver-rules-brake.md
@@ -1,0 +1,5 @@
+---
+"signal-form": patch
+---
+
+Remove `id` spcecial case for field arrays

--- a/lib/use-fields-array.ts
+++ b/lib/use-fields-array.ts
@@ -18,7 +18,7 @@ export function useFieldsArray<T = any>(fieldName: string): FieldArray<T> {
     return {
       ...field,
       keys: computed(() =>
-        (field.data.value || []).map((row, index) => (row as any)?.id || index)
+        (field.data.value || []).map((row, index) => index.toString())
       ),
       push(value: T) {
         field.setData([...(field.data.value || []), value]);


### PR DESCRIPTION
Previously we figured that using an `id` for the row element would be preferable to just using the index, but this is not the case. This just causes bugs and unexpected behaviour. Using the indexes is really only there so we don't rerender unnecessarily, so let's just remove this.